### PR TITLE
Form for downloading needs CSRF input

### DIFF
--- a/downloadassets/templates/widget.html
+++ b/downloadassets/templates/widget.html
@@ -2,6 +2,7 @@
 
 <form method="post">
 	<input type="hidden" name="action" value="downloadAssets/download">
+	{{ getCsrfInput() }}
 	{% set sources = craft.downloadAssets.getSourcesOptGroup() %}
 	{{ forms.selectField({
 		label: "Source:"|t,


### PR DESCRIPTION
 ...so as not to throw an error in installations that have that setting enabled in config.
